### PR TITLE
Fix Manhattan asset path

### DIFF
--- a/react_template/src/components/viewer/BabylonJsRenderer.jsx
+++ b/react_template/src/components/viewer/BabylonJsRenderer.jsx
@@ -276,9 +276,9 @@ const BabylonJsRenderer = forwardRef(({ assetId, renderMode = 'realtime' }, ref)
               modelPath = '/assets/models/nagoya_downtown.glb';
               break;
             case 'environment-nyc-manhattan':
-              // Use the direct path to the uploaded FBX file instead of the assets folder
-              modelPath = '/data/chats/0qr5w/workspace/uploads/NewYork-City-Manhattan.fbx';
-              console.log('Loading NYC Manhattan FBX model from direct upload path:', modelPath);
+              // Use the bundled Manhattan model
+              modelPath = '/assets/models/NewYork-City-Manhattan.fbx';
+              console.log('Loading NYC Manhattan FBX model from assets path:', modelPath);
               break;
             case 'prop-pirates-ship':
               modelPath = '/assets/models/catroonic_pirates_ship.glb';

--- a/react_template/src/services/StorageService.js
+++ b/react_template/src/services/StorageService.js
@@ -216,7 +216,7 @@ class StorageService {
       ['urban', 'newyork', 'manhattan', 'city', 'photorealistic', 'skyline'],
       'FBX',
       false,
-      '/data/chats/0qr5w/workspace/uploads/NewYork-City-Manhattan.fbx' // direct path to uploaded file
+      '/assets/models/NewYork-City-Manhattan.fbx' // actual model path
     ));
     
     // Add Pirates Ship prop


### PR DESCRIPTION
## Summary
- use correct Manhattan model path in StorageService
- load Manhattan model from public assets in BabylonJsRenderer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*